### PR TITLE
Added the option to ignore variables based on a prefix

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -33,7 +33,7 @@ module.exports = function(grunt) {
       json: {
         options: {
           format: 'json', // by default,
-          ignorePrefix: '_' // for testing
+          ignoreWithPrefix: '_' // for testing
         },
         files: {
           'test/output/variables.json': 'test/input/variables.less'

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -32,7 +32,8 @@ module.exports = function(grunt) {
     less2js: {
       json: {
         options: {
-          format: 'json' // by default
+          format: 'json', // by default,
+          ignorePrefix: '_' // for testing
         },
         files: {
           'test/output/variables.json': 'test/input/variables.less'

--- a/README.md
+++ b/README.md
@@ -50,11 +50,11 @@ Default value: `'json'`
 A type of output file contents. 
 Available values: `'json'` (basic valid json), `'ng'` (angular-js module)
 
-#### options.ignorePrefix
+#### options.ignoreWithPrefix
 Type: `String`
 Default value: `''`
 
-If a variable starts with the ignorePrefix, it will be omitted from the JSON file.
+If a variable starts with the ignoreWithPrefix, it will be omitted from the JSON file.
 For example: `_` would ignore `@_base`.
 
 #### options.ngModule

--- a/README.md
+++ b/README.md
@@ -50,6 +50,13 @@ Default value: `'json'`
 A type of output file contents. 
 Available values: `'json'` (basic valid json), `'ng'` (angular-js module)
 
+#### options.ignorePrefix
+Type: `String`
+Default value: `''`
+
+If a variable starts with the ignorePrefix, it will be omitted from the JSON file.
+For example: `_` would ignore `@_base`.
+
 #### options.ngModule
 Type: `String`
 Default value: `'%path to output file%'`

--- a/tasks/less2js.js
+++ b/tasks/less2js.js
@@ -17,6 +17,7 @@ module.exports = function (grunt) {
     var options = this.options({
       banner: '// DO NOT EDIT! GENERATED AUTOMATICALLY with grunt-less2js',
       format: 'json',  // available values: "json", "ng"
+      ignorePrefix: '', // any valid string e.g. "_" would ignore @_base
       ngModule: '',    // angular-js module name (only when format="ng")
       ngConstant: ''   // angular-js injectable constant name (only when format="ng")
     });
@@ -34,12 +35,16 @@ module.exports = function (grunt) {
         parser.parse(content, function (err, tree) {
           var env = new less.tree.evalEnv();
           var ruleset = tree.eval(env); // jshint ignore:line
+          var regex = options.ignorePrefix ? new RegExp('^' + options.ignorePrefix) : null;
 
           ruleset.rules.forEach(function (rule) {
             if (rule.variable) {
               var name = rule.name.substr(1); // remove "@"
-              var value = rule.value.value[0]; // can be less.tree.Color, less.tree.Expression, etc.
-              lessVars[name] = value.toCSS();
+
+              if (!regex || !regex.test(name)) {
+                var value = rule.value.value[0]; // can be less.tree.Color, less.tree.Expression, etc.
+                lessVars[name] = value.toCSS();
+              }
             }
           });
         });

--- a/tasks/less2js.js
+++ b/tasks/less2js.js
@@ -17,7 +17,7 @@ module.exports = function (grunt) {
     var options = this.options({
       banner: '// DO NOT EDIT! GENERATED AUTOMATICALLY with grunt-less2js',
       format: 'json',  // available values: "json", "ng"
-      ignorePrefix: '', // any valid string e.g. "_" would ignore @_base
+      ignoreWithPrefix: '', // any valid string e.g. "_" would ignore @_base
       ngModule: '',    // angular-js module name (only when format="ng")
       ngConstant: ''   // angular-js injectable constant name (only when format="ng")
     });
@@ -35,13 +35,13 @@ module.exports = function (grunt) {
         parser.parse(content, function (err, tree) {
           var env = new less.tree.evalEnv();
           var ruleset = tree.eval(env); // jshint ignore:line
-          var regex = options.ignorePrefix ? new RegExp('^' + options.ignorePrefix) : null;
+          var prefix = options.ignoreWithPrefix || null;
 
           ruleset.rules.forEach(function (rule) {
             if (rule.variable) {
               var name = rule.name.substr(1); // remove "@"
 
-              if (!regex || !regex.test(name)) {
+              if (!prefix || name.substr(0, prefix.length) !== prefix) {
                 var value = rule.value.value[0]; // can be less.tree.Color, less.tree.Expression, etc.
                 lessVars[name] = value.toCSS();
               }

--- a/test/input/variables.less
+++ b/test/input/variables.less
@@ -18,3 +18,6 @@
 @boxShadow: 0 0 @blurRadius black;
 @someText: 'Some value is @{someValue}';
 @fontBase: @fontSize ~"Helvetica Neue, Arial, sans-serif";
+
+// ignored prefix
+@_inverse: '#ccc';

--- a/test/less2js_test.js
+++ b/test/less2js_test.js
@@ -54,5 +54,12 @@ exports.less2js = {
     });
 
     test.done();
+  },
+  test_ignore_prefix: function(test) {
+    var json = grunt.file.readJSON('test/output/variables.json');
+
+    test.ok(!json.hasOwnProperty('_inverse'));
+
+    test.done();
   }
 };


### PR DESCRIPTION
I found that I needed to be able to omit certain variables from my JSON file and the simplest way to do that was to namespace them.  I was thinking this might be useful to someone else as well so I figured I'd contribute back.

Please let me know if there's anything else I need to do.
